### PR TITLE
Convert line endings from CRLF to LF.

### DIFF
--- a/aFileChooser/res/xml/mimetypes.xml
+++ b/aFileChooser/res/xml/mimetypes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
  * Copyright (C) 2007-2008 OpenIntents.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@
 	<type extension=".tiff" mimetype="image/tiff" />
 	<type extension=".tif" mimetype="image/tiff" />
 	<type extension=".icon" mimetype="image/x-icon" />
-	    
+
 	<!-- Audio types -->
 	<type extension=".mp3" mimetype="audio/mpeg" />
 	<type extension=".mp2" mimetype="audio/mpeg" />
@@ -43,10 +43,10 @@
 	<type extension=".aif" mimetype="audio/x-aiff"/>
 	<type extension=".aiff" mimetype="audio/x-aiff"/>
 	<type extension=".aifc" mimetype="audio/x-aiff"/>
-			
+
 	<!-- Video types -->
 	<type extension=".mpeg" mimetype="video/mpeg" />
-	<type extension=".mpg" mimetype="video/mpeg" />	
+	<type extension=".mpg" mimetype="video/mpeg" />
 	<type extension=".mpe" mimetype="video/mpeg" />
 	<type extension=".mov" mimetype="video/quicktime" />
 	<type extension=".qt" mimetype="video/quicktime" />
@@ -58,18 +58,18 @@
 	<type extension=".flv" mimetype="video/x-flv" />
 	<type extension=".wmx" mimetype="video/x-ms-wmv" />
 	<type extension=".avi" mimetype="video/x-msvideo" />
-			
+
 	<!-- Package types -->
 	<type extension=".jar" mimetype="application/java-archive" />
 	<type extension=".zip" mimetype="application/zip" />
 	<type extension=".rar" mimetype="application/x-rar-compressed" />
 	<type extension=".gz" mimetype="application/gzip" />
-	
+
 	<!-- Web browser types -->
 	<type extension=".htm" mimetype="text/html" />
 	<type extension=".html" mimetype="text/html" />
 	<type extension=".php" mimetype="text/php " />
-	
+
 	<!-- Doc types -->
 	<type extension=".txt" mimetype="text/plain" />
 	<type extension=".rtf" mimetype="text/rtf" />
@@ -82,8 +82,8 @@
 	<type extension=".ppt" mimetype="application/vnd.ms-powerpoint" />
 	<type extension=".pdf" mimetype="application/pdf" />
 	<type extension=".xls" mimetype="application/vnd.ms-excel" />
-	
+
 	<!-- Android specific -->
 	<type extension=".apk" mimetype="application/vnd.android.package-archive" />
-	
+
 </MimeTypes>

--- a/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
+++ b/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
@@ -46,7 +46,7 @@ import java.util.Comparator;
  */
 public class FileUtils {
     private FileUtils() {} //private constructor to enforce Singleton pattern
-    
+
     /** TAG for log messages. */
     static final String TAG = "FileUtils";
     private static final boolean DEBUG = false; // Set to true to enable logging
@@ -247,7 +247,7 @@ public class FileUtils {
      * <br>
      * Callers should check whether the path is local before assuming it
      * represents a local file.
-     * 
+     *
      * @param context The context.
      * @param uri The Uri to query.
      * @see #isLocal(String)


### PR DESCRIPTION
- This commit does not introduce any code change!

> Formatting and whitespace issues are some of the more frustrating and subtle problems that many developers encounter when collaborating, especially cross-platform. It’s very easy for patches or other collaborated work to introduce subtle whitespace changes because editors silently introduce them, and if your files ever touch a Windows system, their line endings might be replaced. Git has a few configuration options to help with these issues.
> 
> `core.autocrlf`
> 
> If you’re programming on Windows and working with people who are not (or vice-versa), you’ll probably run into line-ending issues at some point. This is because Windows uses both a carriage-return character and a linefeed character for newlines in its files, whereas Mac and Linux systems use only the linefeed character. This is a subtle but incredibly annoying fact of cross-platform work; many editors on Windows silently replace existing LF-style line endings with CRLF, or insert both line-ending characters when the user hits the enter key.
> 
> Git can handle this by auto-converting CRLF line endings into LF when you add a file to the index, and vice versa when it checks out code onto your filesystem ...

Source: [Git documentation - Configuration - Formatting-and-Whitespace](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#Formatting-and-Whitespace)
