### PR TITLE
Fix for external SDCard on Android M

### DIFF
--- a/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
+++ b/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java
@@ -286,7 +286,12 @@ public class FileUtils {
                     return Environment.getExternalStorageDirectory() + "/" + split[1];
                 }
 
-                // TODO handle non-primary volumes
+                // Since Android M, the external SD Card used as portable storage shows the
+                // SDCard ID as DocumentsContract first parameter.
+                // So docId has the following format: XXXX-XXXX:path/to/the/file
+                if (type.matches("[A-F0-9]{4}-[A-F0-9]{4}")) {
+                    return "/storage/".concat(type).concat("/").concat(split[1]);
+                }
             }
             // DownloadsProvider
             else if (isDownloadsDocument(uri)) {


### PR DESCRIPTION
Starting from Android M, the external SD Card used as portable storage shows the SDCard ID as DocumentsContract first parameter.

So docId has the following format: `XXXX-XXXX:path/to/the/file`
And the real path would be: `/storage/XXXX-XXXX/path/to/the/file`

```
if (type.matches("[A-F0-9]{4}-[A-F0-9]{4}")) {
     return "/storage/".concat(type).concat("/").concat(split[1]);
}
```

Tested on Moto X Play 6.0. Someone can confirm that it's the same for other devices? I don't like at all handwrite the "storage" path, and maybe the type is not always an SDCard ID.

We should discuss this before merge.
